### PR TITLE
fix(drawing): correct opacity handling for text and shapes

### DIFF
--- a/src/api/drawing/path-builder.ts
+++ b/src/api/drawing/path-builder.ts
@@ -276,7 +276,7 @@ export class PathBuilder {
       dashArray: options.dashArray,
       dashPhase: options.dashPhase,
       windingRule: options.windingRule,
-      graphicsStateName: gsName ?? undefined,
+      graphicsStateName: gsName ? `/${gsName}` : undefined,
     });
 
     this.emitOps(ops);

--- a/src/api/pdf-page.ts
+++ b/src/api/pdf-page.ts
@@ -885,7 +885,7 @@ export class PDFPage {
       dashArray: options.borderDashArray,
       dashPhase: options.borderDashPhase,
       cornerRadius: options.cornerRadius,
-      graphicsStateName: gsName ?? undefined,
+      graphicsStateName: gsName ? `/${gsName}` : undefined,
       rotate,
     });
 
@@ -931,7 +931,7 @@ export class PDFPage {
       dashArray: options.dashArray,
       dashPhase: options.dashPhase,
       lineCap: options.lineCap,
-      graphicsStateName: gsName ?? undefined,
+      graphicsStateName: gsName ? `/${gsName}` : undefined,
     });
 
     this.appendOperators(ops);
@@ -966,7 +966,7 @@ export class PDFPage {
       fillColor: options.color,
       strokeColor: options.borderColor,
       strokeWidth: options.borderWidth,
-      graphicsStateName: gsName ?? undefined,
+      graphicsStateName: gsName ? `/${gsName}` : undefined,
     });
 
     this.appendOperators(ops);
@@ -1017,7 +1017,7 @@ export class PDFPage {
       fillColor: options.color,
       strokeColor: options.borderColor,
       strokeWidth: options.borderWidth,
-      graphicsStateName: gsName ?? undefined,
+      graphicsStateName: gsName ? `/${gsName}` : undefined,
       rotate,
     });
 
@@ -1099,7 +1099,7 @@ export class PDFPage {
     const ops: Operator[] = [pushGraphicsState()];
 
     if (gsName) {
-      ops.push(setGraphicsState(gsName));
+      ops.push(setGraphicsState(`/${gsName}`));
     }
 
     // Apply rotation if specified
@@ -2035,11 +2035,11 @@ export class PDFPage {
     const gsDict = new PdfDict();
 
     if (params.ca !== undefined) {
-      gsDict.set("ca", PdfNumber.of(params.ca)); // Stroke opacity
+      gsDict.set("ca", PdfNumber.of(params.ca)); // Non-stroking (fill) opacity
     }
 
     if (params.CA !== undefined) {
-      gsDict.set("CA", PdfNumber.of(params.CA)); // Fill opacity
+      gsDict.set("CA", PdfNumber.of(params.CA)); // Stroking opacity
     }
 
     // Generate unique name
@@ -2261,11 +2261,11 @@ export class PDFPage {
     const params: { ca?: number; CA?: number } = {};
 
     if (fillOpacity !== undefined) {
-      params.CA = Math.max(0, Math.min(1, fillOpacity)); // Fill opacity
+      params.ca = Math.max(0, Math.min(1, fillOpacity)); // Non-stroking (fill) opacity
     }
 
     if (strokeOpacity !== undefined) {
-      params.ca = Math.max(0, Math.min(1, strokeOpacity)); // Stroke opacity
+      params.CA = Math.max(0, Math.min(1, strokeOpacity)); // Stroking opacity
     }
 
     return this.addGraphicsState(params);


### PR DESCRIPTION
Two bugs were causing opacity to not work:

1. Swapped CA/ca parameters in registerGraphicsStateForOpacity:
   - CA (uppercase) is for stroking operations (borders)
   - ca (lowercase) is for non-stroking operations (fills, text)

2. Missing '/' prefix when setting graphics state:
   - setGraphicsState expects '/GS0' but was receiving 'GS0'

Added comprehensive opacity tests for all drawing methods including
rectangles, circles, ellipses, lines, text, paths, and images.

Resolves #4 

<img width="588" height="757" alt="image" src="https://github.com/user-attachments/assets/c5b81745-4e13-4cb1-b6ec-6cd06ead8fec" />
