### PR TITLE
fix(api): resolve indirect refs in resource subdictionaries

### DIFF
--- a/fixtures/scenarios/indirect-xobject-resources.pdf
+++ b/fixtures/scenarios/indirect-xobject-resources.pdf
@@ -1,0 +1,144 @@
+%PDF-1.7
+%‚„œ”
+2 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+3 0 obj
+<<
+/Title (Untitled)
+/Author (Unknown)
+/Creator (@libpdf/core)
+/Producer (@libpdf/core)
+/CreationDate (D:20260220114631Z)
+/ModDate (D:20260220114631Z)
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 595 842]
+/Resources <<
+/XObject 7 0 R
+>>
+/Parent 1 0 R
+/Contents 6 0 R
+>>
+endobj
+1 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+5 0 obj
+<<
+/Length 440/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 595 842]
+/Resources <<
+/Font <<
+/F0 <<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+>>
+>>
+>>
+stream
+q
+
+
+q
+0.95 0.95 0.95 rg
+0 0 m
+595 0 l
+595 842 l
+0 842 l
+h
+f
+Q
+
+Q
+
+q
+0.2 0.2 0.2 rg
+BT
+/F0 24 Tf
+1 0 0 1 100 600 Tm
+<4F524947494E414C205041474520434F4E54454E54> Tj
+ET
+Q
+
+q
+0.4 0.1 0.1 rg
+BT
+/F0 14 Tf
+1 0 0 1 100 550 Tm
+<546869732074657874206D757374207375727669766520656D62656450616765202B206472617750616765> Tj
+ET
+Q
+
+q
+0.8 0.2 0.2 rg
+50 200 m
+250 200 l
+250 350 l
+50 350 l
+h
+f
+Q
+
+q
+0.2 0.2 0.8 rg
+300 200 m
+500 200 l
+500 350 l
+300 350 l
+h
+f
+Q
+endstream
+endobj
+6 0 obj
+<<
+/Length 27>>
+stream
+
+q
+1 0 0 1 0 0 cm
+/Fm0 Do
+Q
+endstream
+endobj
+7 0 obj
+<<
+/Fm0 5 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f
+0000000352 00000 n
+0000000015 00000 n
+0000000064 00000 n
+0000000233 00000 n
+0000000409 00000 n
+0000001076 00000 n
+0000001152 00000 n
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 3 0 R
+/ID [<7FE72669B8A91FD2B4EB691A3D02BEFB> <7FE72669B8A91FD2B4EB691A3D02BEFB>]
+>>
+startxref
+1184
+%%EOF

--- a/src/api/pdf-page.ts
+++ b/src/api/pdf-page.ts
@@ -2360,7 +2360,7 @@ export class PDFPage {
    */
   private addXObjectResource(ref: PdfRef): string {
     const resources = this.getResources();
-    let xobjects = resources.get("XObject");
+    let xobjects = resources.get("XObject", this.ctx.resolve.bind(this.ctx));
 
     if (!(xobjects instanceof PdfDict)) {
       xobjects = new PdfDict();
@@ -2409,7 +2409,7 @@ export class PDFPage {
 
     // Get or create the resource subdictionary
     const resources = this.getResources();
-    let subdict = resources.get(resourceType);
+    let subdict = resources.get(resourceType, this.ctx.resolve.bind(this.ctx));
 
     if (!(subdict instanceof PdfDict)) {
       subdict = new PdfDict();

--- a/src/tests/issues/drawpage-indirect-xobject-resources.test.ts
+++ b/src/tests/issues/drawpage-indirect-xobject-resources.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression test: drawPage / embedPage loses existing page content
+ * when the page's Resources/XObject subdictionary is an indirect reference.
+ *
+ * The bug: `addXObjectResource` and `registerResource` in PDFPage called
+ * `resources.get("XObject")` without passing a resolver. When the XObject
+ * entry was a PdfRef (indirect object), the check `!(xobjects instanceof PdfDict)`
+ * evaluated to true, causing the method to create a brand-new empty PdfDict
+ * and overwrite the existing XObject dictionary. This silently dropped all
+ * pre-existing XObject entries (images, form XObjects, etc.), making the
+ * original page content invisible.
+ *
+ * PDFs produced by scanners (e.g. Konica Minolta) commonly use this structure:
+ * the page content is a single `Do` operator referencing an Image XObject,
+ * and the Resources/XObject dict is stored as an indirect object.
+ *
+ * The fixture `scenarios/indirect-xobject-resources.pdf` has a page whose
+ * /Resources /XObject is an indirect PdfRef pointing to a dict with an
+ * existing Form XObject (`Fm0`) that renders the visible page content.
+ */
+
+import { PDF } from "#src/api/pdf";
+import { PdfDict } from "#src/objects/pdf-dict";
+import { PdfRef } from "#src/objects/pdf-ref";
+import { loadFixture, saveTestOutput } from "#src/test-utils";
+import { describe, expect, it } from "vitest";
+
+describe("drawPage with indirect XObject resources", () => {
+  it("preserves existing XObject entries when Resources/XObject is an indirect ref", async () => {
+    const pdfBytes = await loadFixture("scenarios", "indirect-xobject-resources.pdf");
+    const pdf = await PDF.load(pdfBytes);
+    const page = pdf.getPage(0)!;
+
+    const resolve = (ref: PdfRef) => pdf.getObject(ref);
+    const resources = page.getResources();
+
+    // Precondition: the XObject subdict is an indirect reference
+    const xobjectsRaw = resources.get("XObject");
+    expect(xobjectsRaw).toBeInstanceOf(PdfRef);
+
+    // Precondition: it resolves to a dict containing the original XObject
+    const xobjectsBefore = resources.get("XObject", resolve) as PdfDict;
+    expect(xobjectsBefore).toBeInstanceOf(PdfDict);
+
+    const originalKeys = [...xobjectsBefore.keys()].map(k => k.value);
+    expect(originalKeys).toContain("Fm0");
+
+    // embedPage + drawPage (the Documenso overlay pattern)
+    const overlayPdf = PDF.create();
+    const overlayPage = overlayPdf.addPage({ width: page.width, height: page.height });
+
+    overlayPage.drawText("OVERLAY", {
+      x: 100,
+      y: 100,
+      size: 20,
+      color: { type: "RGB", red: 0, green: 0, blue: 0 },
+    });
+
+    const overlayDoc = await PDF.load(await overlayPdf.save());
+    const embedded = await pdf.embedPage(overlayDoc, 0);
+
+    page.drawPage(embedded, { x: 0, y: 0 });
+
+    // The XObject dict must still contain the original entry
+    const xobjectsAfter = resources.get("XObject", resolve) as PdfDict;
+
+    expect(xobjectsAfter).toBeInstanceOf(PdfDict);
+    expect(xobjectsAfter.has("Fm0")).toBe(true);
+
+    // And also the newly added form XObject (Fm1 since Fm0 is taken)
+    const afterKeys = [...xobjectsAfter.keys()].map(k => k.value);
+    expect(afterKeys.length).toBeGreaterThan(originalKeys.length);
+
+    // Save, reload, verify content survives round-trip
+    const savedBytes = await pdf.save({ useXRefStream: true });
+
+    await saveTestOutput("issues/drawpage-indirect-xobject.pdf", savedBytes);
+
+    const reloaded = await PDF.load(savedBytes);
+    const reloadedPage = reloaded.getPage(0)!;
+    const reloadedResolve = (ref: PdfRef) => reloaded.getObject(ref);
+    const reloadedXObjects = reloadedPage.getResources().get("XObject", reloadedResolve) as PdfDict;
+
+    expect(reloadedXObjects).toBeInstanceOf(PdfDict);
+
+    // Original XObject must still be there
+    expect(reloadedXObjects.has("Fm0")).toBe(true);
+  });
+
+  it("preserves content through the full flatten + embed + flatten flow", async () => {
+    const pdfBytes = await loadFixture("scenarios", "indirect-xobject-resources.pdf");
+    const pdf = await PDF.load(pdfBytes);
+    const page = pdf.getPage(0)!;
+
+    // Step 1: flattenAll (like Documenso does before signing)
+    pdf.flattenAll();
+
+    // Step 2: embed + draw overlay
+    const overlayPdf = PDF.create();
+    const overlayPage = overlayPdf.addPage({ width: page.width, height: page.height });
+
+    overlayPage.drawRectangle({
+      x: 50,
+      y: 50,
+      width: 200,
+      height: 40,
+      color: { type: "RGB", red: 0.9, green: 0.9, blue: 1 },
+      borderColor: { type: "RGB", red: 0, green: 0, blue: 0.5 },
+      borderWidth: 1,
+    });
+
+    const overlayDoc = await PDF.load(await overlayPdf.save());
+    const embedded = await pdf.embedPage(overlayDoc, 0);
+
+    page.drawPage(embedded, { x: 0, y: 0 });
+
+    // Step 3: flattenAll again
+    pdf.flattenAll();
+
+    // Step 4: Save with xref stream
+    const savedBytes = await pdf.save({ useXRefStream: true });
+
+    await saveTestOutput("issues/drawpage-indirect-xobject-full-flow.pdf", savedBytes);
+
+    // The file should not have lost the original XObject data.
+    // Before the fix, the file shrank dramatically because the original
+    // Form XObject (the entire visible page content) was silently dropped.
+    expect(savedBytes.length).toBeGreaterThan(pdfBytes.length * 0.5);
+
+    // Reload and verify original XObject is still present
+    const reloaded = await PDF.load(savedBytes);
+
+    const reloadedPage = reloaded.getPage(0)!;
+    const resolve = (ref: PdfRef) => reloaded.getObject(ref);
+    const xobjects = reloadedPage.getResources().get("XObject", resolve) as PdfDict;
+
+    expect(xobjects).toBeInstanceOf(PdfDict);
+
+    const keys = [...xobjects.keys()].map(k => k.value);
+
+    expect(keys).toContain("Fm0");
+    expect(keys.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
addXObjectResource and registerResource called resources.get()
without a resolver, so when a resource subdictionary (e.g. /XObject)
was stored as an indirect PdfRef, it failed the instanceof PdfDict
check and silently replaced the existing dict with an empty one.

This dropped all pre-existing resource entries. Scanner-produced PDFs
(e.g. Konica Minolta) commonly store /Resources /XObject as an
indirect object, so embedPage + drawPage on those PDFs would erase
the original page content entirely.

addFontResource already passed the resolver correctly; this aligns
the other two methods to match.
