### PR TITLE
perf: reduce allocations and copies in load-modify-save path

### DIFF
--- a/scripts/profile-load-save.ts
+++ b/scripts/profile-load-save.ts
@@ -1,0 +1,41 @@
+/**
+ * CPU profiling script for load-modify-save workflow.
+ *
+ * Usage: bun --cpu-prof-md scripts/profile-load-save.ts
+ *
+ * Runs the load → modify → save cycle multiple times to get
+ * a representative CPU profile showing where time is spent.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { PDF } from "../src/index.ts";
+
+const HEAVY_PDF = "fixtures/benchmarks/cc-journalists-guide.pdf";
+const ITERATIONS = 20;
+
+const pdfBytes = new Uint8Array(readFileSync(HEAVY_PDF));
+console.log(`PDF size: ${(pdfBytes.length / 1024 / 1024).toFixed(1)}MB`);
+
+// Warm up
+{
+  const pdf = await PDF.load(pdfBytes);
+  const page = pdf.getPage(0)!;
+  page.drawRectangle({ x: 50, y: 50, width: 100, height: 100 });
+  await pdf.save();
+}
+
+console.log(`Running ${ITERATIONS} iterations of load → modify → save...`);
+
+const start = performance.now();
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const pdf = await PDF.load(pdfBytes);
+  const page = pdf.getPage(0)!;
+  page.drawRectangle({ x: 50, y: 50, width: 100, height: 100 });
+  await pdf.save();
+}
+
+const elapsed = performance.now() - start;
+console.log(`Total: ${elapsed.toFixed(0)}ms`);
+console.log(`Average: ${(elapsed / ITERATIONS).toFixed(1)}ms per iteration`);

--- a/src/filters/ascii-hex-filter.ts
+++ b/src/filters/ascii-hex-filter.ts
@@ -22,7 +22,9 @@ export class ASCIIHexFilter implements Filter {
   private static readonly NIBBLE_MASK = 0x0f;
 
   decode(data: Uint8Array, _params?: PdfDict): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: Math.ceil(data.length / 2), // Hex is 2 chars per byte
+    });
 
     let high: number | null = null;
 

--- a/src/filters/ascii85-filter.ts
+++ b/src/filters/ascii85-filter.ts
@@ -25,7 +25,9 @@ export class ASCII85Filter implements Filter {
   private static readonly ZERO_SHORTCUT = 0x7a;
 
   decode(data: Uint8Array, _params?: PdfDict): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: Math.ceil((data.length * 4) / 5), // Estimate output size
+    });
 
     let buffer = 0;
     let count = 0;
@@ -102,7 +104,9 @@ export class ASCII85Filter implements Filter {
   }
 
   encode(data: Uint8Array, _params?: PdfDict): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: Math.ceil((data.length * 5) / 4) + 2, // Estimate output size + end marker
+    });
 
     // Process 4 bytes at a time
     let i = 0;

--- a/src/filters/lzw-filter.ts
+++ b/src/filters/lzw-filter.ts
@@ -43,7 +43,9 @@ export class LZWFilter implements Filter {
   }
 
   private lzwDecode(data: Uint8Array, earlyChange: number): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: data.length * 4, // Estimate output size (LZW can expand up to 4x)
+    });
 
     // LZW constants
     // Bit reading state

--- a/src/filters/run-length-filter.ts
+++ b/src/filters/run-length-filter.ts
@@ -19,7 +19,9 @@ export class RunLengthFilter implements Filter {
   readonly name = "RunLengthDecode";
 
   decode(data: Uint8Array, _params?: PdfDict): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: data.length * 4, // Estimate output size (RLE can expand up to 4x)
+    });
     let i = 0;
 
     while (i < data.length) {
@@ -52,7 +54,10 @@ export class RunLengthFilter implements Filter {
   }
 
   encode(data: Uint8Array, _params?: PdfDict): Uint8Array {
-    const output = new ByteWriter();
+    const output = new ByteWriter(undefined, {
+      initialSize: data.length * 2, // Worst case (no runs)
+    });
+
     let i = 0;
 
     while (i < data.length) {

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -96,6 +96,8 @@ export function parsePdfDate(str: string): Date | undefined {
 // Number Formatting
 // ─────────────────────────────────────────────────────────────────────────────
 
+const TRAILING_ZERO_REGEX = /\.?0+$/;
+
 /**
  * Format a number for PDF output.
  *
@@ -112,7 +114,7 @@ export function formatPdfNumber(value: number): string {
   let str = value.toFixed(5);
 
   // Remove trailing zeros and unnecessary decimal point
-  str = str.replace(/\.?0+$/, "");
+  str = str.replace(TRAILING_ZERO_REGEX, "");
 
   // Handle edge case where we stripped everything after decimal
   if (str === "" || str === "-") {

--- a/src/parser/indirect-object-parser.ts
+++ b/src/parser/indirect-object-parser.ts
@@ -132,9 +132,12 @@ export class IndirectObjectParser {
     // Get the stream length
     const length = this.resolveLength(dict);
 
-    // Read exactly `length` bytes
+    // Read exactly `length` bytes.
+    // Use subarray (zero-copy view) since the underlying PDF bytes
+    // are kept alive by the PDF object for the document's lifetime.
     const startPos = this.scanner.position;
-    const data = this.scanner.bytes.slice(startPos, startPos + length);
+    const data = this.scanner.bytes.subarray(startPos, startPos + length);
+
     this.scanner.moveTo(startPos + length);
 
     // Skip optional EOL before "endstream"

--- a/src/writer/pdf-writer.ts
+++ b/src/writer/pdf-writer.ts
@@ -73,6 +73,14 @@ export interface WriteOptions {
    * The encrypt dictionary reference must also be provided.
    */
   securityHandler?: StandardSecurityHandler;
+
+  /**
+   * Hint for the final PDF size in bytes.
+   *
+   * When provided, the ByteWriter will pre-allocate a buffer of this size,
+   * reducing the need for reallocations during writing.
+   */
+  sizeHint?: number;
 }
 
 /**
@@ -341,7 +349,10 @@ function collectReachableRefs(
  * ```
  */
 export function writeComplete(registry: ObjectRegistry, options: WriteOptions): WriteResult {
-  const writer = new ByteWriter();
+  const writer = new ByteWriter(undefined, {
+    initialSize: options.sizeHint,
+  });
+
   const compress = options.compressStreams ?? true;
   const threshold = options.compressionThreshold ?? DEFAULT_COMPRESSION_THRESHOLD;
 

--- a/src/writer/serializer.ts
+++ b/src/writer/serializer.ts
@@ -18,7 +18,9 @@ import type { PdfRef } from "#src/objects/pdf-ref";
  * @returns The PDF byte representation
  */
 export function serializeObject(obj: PdfObject): Uint8Array {
-  const writer = new ByteWriter();
+  const writer = new ByteWriter(undefined, {
+    initialSize: 256, // Start with a reasonable buffer size
+  });
 
   // All PdfObject types implement PdfPrimitive
   obj.toBytes(writer);
@@ -36,7 +38,9 @@ export function serializeObject(obj: PdfObject): Uint8Array {
  * @returns The complete indirect object definition
  */
 export function serializeIndirectObject(ref: PdfRef, obj: PdfObject): Uint8Array {
-  const writer = new ByteWriter();
+  const writer = new ByteWriter(undefined, {
+    initialSize: 256, // Start with a reasonable buffer size
+  });
 
   writer.writeAscii(`${ref.objectNumber} ${ref.generation} obj\n`);
   obj.toBytes(writer);


### PR DESCRIPTION
Improves performance of the load → modify → save cycle.

**Why:** We were only ~1.5x faster than pdf-lib for load/modify/save, which is underwhelming given our architectural advantages.

**How:** Profiling showed the bottleneck was allocation churn and unnecessary copying. This PR:
- Pre-sizes ByteWriter buffers using size hints (original PDF length for full saves, estimated output sizes for filters) to avoid repeated geometric reallocation
- Uses `subarray` instead of `slice` for stream data in the parser — zero-copy views into the original PDF bytes, which stay alive for the document lifetime anyway
- Returns the internal buffer directly from `ByteWriter.toBytes()` when it's already the right size (zero-copy fast path), falls back to `subarray` instead of `slice` for the trimmed case
- Hoists the trailing-zero regex in `formatPdfNumber` out of the function body so it isn't recompiled on every call
- Routes page tree loading through `registry.resolve` so objects are tracked for modification detection