### PR TITLE
fix: register DR font dicts as indirect objects in getOrCreateForm()

### DIFF
--- a/src/api/pdf.ts
+++ b/src/api/pdf.ts
@@ -2686,10 +2686,14 @@ export class PDF {
       BaseFont: PdfName.of("ZapfDingbats"),
     });
 
+    // Register fonts and get references
+    const helveticaRef = this.ctx.registry.register(helveticaDict);
+    const zapfDingbatsRef = this.ctx.registry.register(zapfDingbatsDict);
+
     // Create Font dictionary with standard fonts
     const fontsDict = PdfDict.of({
-      Helv: helveticaDict,
-      ZaDb: zapfDingbatsDict,
+      Helv: helveticaRef,
+      ZaDb: zapfDingbatsRef,
     });
 
     // Create Default Resources dictionary


### PR DESCRIPTION
## Summary

Fixes a compatibility issue where PDFs generated by `getOrCreateForm()` caused iText to
throw during a standard read-only `getAllFormFields()` call:

```
com.itextpdf.kernel.exceptions.PdfException: There is no associate PdfWriter for making indirects.
    at com.itextpdf.kernel.pdf.PdfObject.makeIndirect(PdfObject.java:244)
```

The error affects all field types (text, checkbox, radio, dropdown) and does not require
any misuse of iText — the crash occurs during a plain read operation with no stamping or
writing involved.

## Root Cause

`getOrCreateForm()` previously created the `Helv` and `ZapfDingbats` font dictionaries as
**direct** `PdfDict` objects embedded inline in `/AcroForm/DR/Font`:

```ts
// Before
const fontsDict = PdfDict.of({
  Helv: helveticaDict,   // direct PdfDict — no object number
  ZaDb: zapfDingbatsDict,
});
```

This caused a cascade through the appearance generation pipeline:

1. **`parseExistingFont()`** only captures a `ref` when `fontObj instanceof PdfRef`.
   Direct dicts result in `ref = null`.
2. **`buildFontResources()`** checks `isExistingFont(font) && font.ref`. With `ref = null`
   it falls into the `else` branch and creates a **brand-new direct `PdfDict`** inside
   every widget's appearance stream `/Resources/Font`, instead of reusing the DR entry.
3. iText calls `makeIndirect()` on these unregistered dicts when building its internal
   field model. With no `PdfWriter` present (read-only document), this throws.

## Fix

Register both font dicts via `registry.register()` before embedding them, so they become
proper indirect objects with assigned object numbers:

```ts
// After
const helveticaRef = this.ctx.registry.register(helveticaDict);
const zapfDingbatsRef = this.ctx.registry.register(zapfDingbatsDict);

const fontsDict = PdfDict.of({
  Helv: helveticaRef,   // PdfRef — indirect object
  ZaDb: zapfDingbatsRef,
});
```

With indirect refs in `/DR/Font`, `parseExistingFont()` correctly sets `ref`, and
`buildFontResources()` reuses it in every appearance stream. iText never needs to call
`makeIndirect()` on anything.