### PR TITLE
feat(signatures): tighten SignatureField.isSigned and add getSignedFields

### DIFF
--- a/.agents/plans/046-signature-field-is-signed.md
+++ b/.agents/plans/046-signature-field-is-signed.md
@@ -1,0 +1,108 @@
+---
+date: 2026-05-21
+title: Signature Field Is Signed
+---
+
+## Problem
+
+`SignatureField.isSigned()` is `return this.dict.has("V")`. Wrong in normal cases:
+
+- `/V` present but `PdfNull` → reports signed.
+- `/V` resolves to non-dict (number, string, array) → reports signed.
+- `/V` inherited from parent field → reports unsigned (only own dict checked).
+- `/V` dict missing `/Contents` or `/ByteRange` (corrupt / leftover placeholder) → reports signed.
+- DocTimeStamp signatures (`/Type /DocTimeStamp` on `/V`) silently lumped with regular sigs; no way to tell them apart.
+
+`getSignatureDict()` shares the same naivety: no shape validation, no inheritance.
+
+No way for callers to ask "real signature vs timestamp vs empty vs malformed" short of instanceof + dict-poking.
+
+## Goals
+
+- Correct `isSigned()` semantics regardless of construction path.
+- Distinguish signed / timestamp / unsigned / invalid.
+- Honor field-value inheritance (`/V` walked via parent chain).
+- Keep `getSignatureDict()` as low-level escape hatch.
+
+## Non-goals
+
+- Cryptographic verification (separate Tier-2 goal).
+- Parsed `SignatureInfo` (signer, signing time, reason) — follow-up.
+- Changes to AcroForm traversal, widget model, or sign flow.
+
+## Desired API
+
+Low-level on `SignatureField` (`src/document/forms/fields/other-fields.ts`):
+
+```ts
+class SignatureField extends TerminalField {
+  /** /V resolves to a Sig or DocTimeStamp dict with Contents + ByteRange. */
+  isSigned(): boolean;
+
+  /** Classification of what sits in /V. */
+  getSignatureStatus(): "unsigned" | "signed" | "timestamp" | "invalid";
+
+  /** True iff /V resolves to /Type /DocTimeStamp. */
+  isDocumentTimestamp(): boolean;
+
+  /** Raw COS dict for /V (resolved + inheritable). null if absent. */
+  getSignatureDict(): PdfDict | null;
+}
+```
+
+Status rules:
+
+- `unsigned`: no `/V` in own dict or any ancestor, or `/V` is `PdfNull`.
+- `signed`: `/V` → `PdfDict`, `/Type` missing or `/Sig`, `/Contents` is non-empty `PdfString`, `/ByteRange` is `PdfArray` of 4 numbers.
+- `timestamp`: same shape, `/Type /DocTimeStamp`.
+- `invalid`: `/V` present, anything above fails.
+
+`isSigned()` ⇔ status ∈ {signed, timestamp}.
+
+High-level on `PDFForm` (`src/api/pdf-form.ts`):
+
+```ts
+form.getSignedFields(): SignatureField[];   // filter where isSigned()
+```
+
+Existing `getSignatureFields()` unchanged.
+
+## Architecture
+
+- Single change site for low-level: `other-fields.ts`. Use `this.getInheritable("V")` (already on `FormField`) instead of `this.dict.get`; resolve refs via `this.registry.resolve`.
+- Shape checks inline in `getSignatureStatus`; other methods delegate.
+- Internal callers in `src/api/pdf-signature.ts` (`findOrCreateSignatureField`, `checkMdpViolation`) keep using `isSigned()`; behavior strictly tighter — no false positives on null/invalid `/V`, no false negatives in real sign flow (sign() always patches a Contents-bearing dict before reload).
+- `getSignedFields()` is a one-liner filter alongside `getSignatureFields()`.
+
+## Test plan
+
+New: `src/document/forms/fields/other-fields.test.ts`. Build in-memory `ObjectRegistry` + `AcroFormLike` per existing field-test patterns.
+
+Cases:
+
+- No `/V` → unsigned.
+- `/V = PdfNull` → unsigned.
+- `/V` inherited from parent /Sig dict with Contents+ByteRange → signed.
+- `/V` → /Sig dict with Contents+ByteRange → signed, not timestamp.
+- `/V` → no `/Type`, Contents+ByteRange → signed (default).
+- `/V` → /DocTimeStamp dict → timestamp; `isSigned` true; `isDocumentTimestamp` true.
+- `/V` → /Sig dict, no /Contents → invalid.
+- `/V` → /Sig dict, Contents present, no /ByteRange → invalid.
+- `/V` → non-dict (number / string / array) → invalid.
+- `getSignatureDict()` returns the resolved dict for signed, timestamp, invalid; null for unsigned.
+
+Extend `src/api/pdf-form.test.ts`: `getSignedFields` partitions signed vs empty signature fields in a multi-sig fixture.
+
+Re-run `src/api/pdf-form.test.ts`, `src/signatures/**`, `examples/07-signatures/*` smoke; no regressions.
+
+## Risks
+
+- Tightening could flip a downstream branch that relied on "any /V counts." Audited: only callers are `pdf-signature.ts` (intent matches new semantics) and example scripts (display-only).
+- `getInheritable("V")` walks parent chain on each call; bounded constant, cheap.
+- New `"invalid"` status is additive; inert until callers opt in.
+
+## Unresolved questions
+
+1. Should `"invalid"` count as `isSigned()` true (preserves today's permissive behavior) or false (proposed)? Proposed false — invalid ≠ signed.
+2. `getSignedFields()` — include DocTimeStamp fields (proposed yes) or split into `getTimestampFields()`?
+3. Keep `getSignatureDict()` raw, or also add a typed `SignatureInfo` view now vs later? Proposed: raw now, typed accessor in follow-up.

--- a/src/api/pdf-form.test.ts
+++ b/src/api/pdf-form.test.ts
@@ -1,4 +1,10 @@
 import type { TerminalField } from "#src/document/forms/fields";
+import { SignatureField } from "#src/document/forms/fields";
+import { PdfArray } from "#src/objects/pdf-array";
+import { PdfDict } from "#src/objects/pdf-dict";
+import { PdfName } from "#src/objects/pdf-name";
+import { PdfNumber } from "#src/objects/pdf-number";
+import { PdfString } from "#src/objects/pdf-string";
 import { loadFixture } from "#src/test-utils";
 import { describe, expect, it } from "vitest";
 
@@ -206,6 +212,73 @@ describe("PDFForm", () => {
       const fields = form!.getCheckboxes();
 
       expect(fields.every(f => f.type === "checkbox")).toBe(true);
+    });
+  });
+
+  describe("getSignedFields", () => {
+    it("returns empty when sig fields are empty placeholders", async () => {
+      const bytes = await loadFixture("forms", "sample_form.pdf");
+      const pdf = await PDF.load(bytes);
+      const form = pdf.getForm();
+
+      expect(form!.getSignatureFields().length).toBeGreaterThan(0);
+      expect(form!.getSignedFields()).toHaveLength(0);
+    });
+
+    it("includes fields with a well-formed signature dict", async () => {
+      const bytes = await loadFixture("forms", "sample_form.pdf");
+      const pdf = await PDF.load(bytes);
+      const form = pdf.getForm();
+
+      const sigField = form!.getSignatureFields()[0];
+      expect(sigField).toBeDefined();
+
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Filter: PdfName.of("Adobe.PPKLite"),
+        SubFilter: PdfName.of("ETSI.CAdES.detached"),
+        Contents: PdfString.fromHex("30820100"),
+        ByteRange: new PdfArray([
+          PdfNumber.of(0),
+          PdfNumber.of(100),
+          PdfNumber.of(200),
+          PdfNumber.of(50),
+        ]),
+      });
+      const sigRef = pdf.context.registry.register(sigDict);
+      sigField.getDict().set("V", sigRef);
+
+      const signed = form!.getSignedFields();
+      expect(signed).toContain(sigField);
+      expect(signed.every(f => f instanceof SignatureField && f.isSigned())).toBe(true);
+    });
+
+    it("includes document timestamp fields", async () => {
+      const bytes = await loadFixture("forms", "sample_form.pdf");
+      const pdf = await PDF.load(bytes);
+      const form = pdf.getForm();
+
+      const sigField = form!.getSignatureFields()[0];
+      expect(sigField).toBeDefined();
+
+      const tsDict = PdfDict.of({
+        Type: PdfName.of("DocTimeStamp"),
+        Filter: PdfName.of("Adobe.PPKLite"),
+        SubFilter: PdfName.of("ETSI.RFC3161"),
+        Contents: PdfString.fromHex("30820100"),
+        ByteRange: new PdfArray([
+          PdfNumber.of(0),
+          PdfNumber.of(100),
+          PdfNumber.of(200),
+          PdfNumber.of(50),
+        ]),
+      });
+      const tsRef = pdf.context.registry.register(tsDict);
+      sigField.getDict().set("V", tsRef);
+
+      const signed = form!.getSignedFields();
+      expect(signed).toContain(sigField);
+      expect(sigField.isDocumentTimestamp()).toBe(true);
     });
   });
 

--- a/src/api/pdf-form.ts
+++ b/src/api/pdf-form.ts
@@ -440,6 +440,18 @@ export class PDFForm {
   }
 
   /**
+   * Get all signature fields that carry a real signature or document timestamp.
+   *
+   * Filters {@link getSignatureFields} via {@link SignatureField.isSigned},
+   * skipping empty placeholders and malformed signature dicts.
+   */
+  getSignedFields(): SignatureField[] {
+    return this.allFields.filter(
+      (f): f is SignatureField => f instanceof SignatureField && f.isSigned(),
+    );
+  }
+
+  /**
    * Get all buttons.
    */
   getButtons(): ButtonField[] {

--- a/src/document/forms/fields/index.ts
+++ b/src/document/forms/fields/index.ts
@@ -10,7 +10,7 @@ export { CheckboxField } from "./checkbox-field";
 export { DropdownField, ListBoxField } from "./choice-fields";
 // Factory
 export { createFormField } from "./factory";
-export { ButtonField, SignatureField, UnknownField } from "./other-fields";
+export { ButtonField, SignatureField, type SignatureStatus, UnknownField } from "./other-fields";
 export { RadioField } from "./radio-field";
 // Field implementations
 export { TextField } from "./text-field";

--- a/src/document/forms/fields/other-fields.test.ts
+++ b/src/document/forms/fields/other-fields.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for SignatureField status classification.
+ */
+
+import { ObjectRegistry } from "#src/document/object-registry";
+import { PdfArray } from "#src/objects/pdf-array";
+import { PdfDict } from "#src/objects/pdf-dict";
+import { PdfName } from "#src/objects/pdf-name";
+import { PdfNull } from "#src/objects/pdf-null";
+import { PdfNumber } from "#src/objects/pdf-number";
+import { PdfString } from "#src/objects/pdf-string";
+import { describe, expect, it } from "vitest";
+
+import { SignatureField } from "./other-fields";
+import type { AcroFormLike } from "./types";
+
+const acroForm: AcroFormLike = { defaultQuadding: 0 };
+
+function makeField(dict: PdfDict): { field: SignatureField; registry: ObjectRegistry } {
+  const registry = new ObjectRegistry();
+  const ref = registry.register(dict);
+  const field = new SignatureField(dict, ref, registry, acroForm, "Signature1");
+
+  return { field, registry };
+}
+
+function byteRange(): PdfArray {
+  return new PdfArray([PdfNumber.of(0), PdfNumber.of(100), PdfNumber.of(200), PdfNumber.of(50)]);
+}
+
+function sigContents(): PdfString {
+  // Non-empty hex string, mimicking patched /Contents bytes.
+  return PdfString.fromHex("30820100");
+}
+
+describe("SignatureField", () => {
+  describe("getSignatureStatus", () => {
+    it("returns 'unsigned' when /V is absent", () => {
+      const { field } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+
+      expect(field.getSignatureStatus()).toBe("unsigned");
+      expect(field.isSigned()).toBe(false);
+      expect(field.isDocumentTimestamp()).toBe(false);
+      expect(field.getSignatureDict()).toBeNull();
+    });
+
+    it("returns 'unsigned' when /V is PdfNull", () => {
+      const { field } = makeField(
+        PdfDict.of({
+          FT: PdfName.of("Sig"),
+          T: PdfString.fromString("Signature1"),
+          V: PdfNull.instance,
+        }),
+      );
+
+      expect(field.getSignatureStatus()).toBe("unsigned");
+      expect(field.isSigned()).toBe(false);
+      expect(field.getSignatureDict()).toBeNull();
+    });
+
+    it("returns 'signed' for a /Type /Sig dict with Contents + ByteRange", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Filter: PdfName.of("Adobe.PPKLite"),
+        SubFilter: PdfName.of("ETSI.CAdES.detached"),
+        Contents: sigContents(),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("signed");
+      expect(field.isSigned()).toBe(true);
+      expect(field.isDocumentTimestamp()).toBe(false);
+      expect(field.getSignatureDict()).toBe(sigDict);
+    });
+
+    it("returns 'signed' when /V dict has no /Type (defaults to Sig)", () => {
+      const sigDict = PdfDict.of({
+        Filter: PdfName.of("Adobe.PPKLite"),
+        Contents: sigContents(),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("signed");
+      expect(field.isSigned()).toBe(true);
+    });
+
+    it("returns 'timestamp' for a /Type /DocTimeStamp dict", () => {
+      const tsDict = PdfDict.of({
+        Type: PdfName.of("DocTimeStamp"),
+        Filter: PdfName.of("Adobe.PPKLite"),
+        SubFilter: PdfName.of("ETSI.RFC3161"),
+        Contents: sigContents(),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Timestamp1") }),
+      );
+      const tsRef = registry.register(tsDict);
+      field.getDict().set("V", tsRef);
+
+      expect(field.getSignatureStatus()).toBe("timestamp");
+      expect(field.isSigned()).toBe(true);
+      expect(field.isDocumentTimestamp()).toBe(true);
+      expect(field.getSignatureDict()).toBe(tsDict);
+    });
+
+    it("walks the parent chain to find inherited /V", () => {
+      const registry = new ObjectRegistry();
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Contents: sigContents(),
+        ByteRange: byteRange(),
+      });
+      const sigRef = registry.register(sigDict);
+
+      const parentDict = PdfDict.of({
+        FT: PdfName.of("Sig"),
+        T: PdfString.fromString("parent"),
+        V: sigRef,
+      });
+      const parentRef = registry.register(parentDict);
+
+      const childDict = PdfDict.of({
+        T: PdfString.fromString("child"),
+        Parent: parentRef,
+      });
+      const childRef = registry.register(childDict);
+
+      const field = new SignatureField(childDict, childRef, registry, acroForm, "parent.child");
+
+      expect(field.getSignatureStatus()).toBe("signed");
+      expect(field.isSigned()).toBe(true);
+      expect(field.getSignatureDict()).toBe(sigDict);
+    });
+
+    it("returns 'invalid' when /V dict has no /Contents", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+      // Dict still surfaced for forensic inspection.
+      expect(field.getSignatureDict()).toBe(sigDict);
+    });
+
+    it("returns 'invalid' when /Contents is empty", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Contents: new PdfString(new Uint8Array(0), "hex"),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+    });
+
+    it("returns 'invalid' when /V dict has no /ByteRange", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Contents: sigContents(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+      expect(field.getSignatureDict()).toBe(sigDict);
+    });
+
+    it("returns 'invalid' when /ByteRange has wrong length", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Contents: sigContents(),
+        ByteRange: new PdfArray([PdfNumber.of(0), PdfNumber.of(100)]),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+    });
+
+    it("returns 'invalid' when /ByteRange contains a non-number", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Sig"),
+        Contents: sigContents(),
+        ByteRange: new PdfArray([
+          PdfNumber.of(0),
+          PdfNumber.of(100),
+          PdfName.of("Bogus"),
+          PdfNumber.of(50),
+        ]),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+    });
+
+    it("returns 'invalid' when /V dict has an unrecognized /Type", () => {
+      const sigDict = PdfDict.of({
+        Type: PdfName.of("Catalog"),
+        Contents: sigContents(),
+        ByteRange: byteRange(),
+      });
+      const { field, registry } = makeField(
+        PdfDict.of({ FT: PdfName.of("Sig"), T: PdfString.fromString("Signature1") }),
+      );
+      const sigRef = registry.register(sigDict);
+      field.getDict().set("V", sigRef);
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+    });
+
+    it("returns 'invalid' when /V is a non-dict primitive", () => {
+      const { field } = makeField(
+        PdfDict.of({
+          FT: PdfName.of("Sig"),
+          T: PdfString.fromString("Signature1"),
+          V: PdfNumber.of(42),
+        }),
+      );
+
+      expect(field.getSignatureStatus()).toBe("invalid");
+      expect(field.isSigned()).toBe(false);
+      // No dict to surface for forensics.
+      expect(field.getSignatureDict()).toBeNull();
+    });
+  });
+});

--- a/src/document/forms/fields/other-fields.ts
+++ b/src/document/forms/fields/other-fields.ts
@@ -10,23 +10,103 @@ import { PdfDict } from "#src/objects/pdf-dict";
 import { TerminalField } from "./base";
 
 /**
+ * Classification of what sits in a signature field's /V entry.
+ *
+ * - `unsigned`: /V is absent (in own dict and ancestors) or explicitly null.
+ * - `signed`: /V resolves to a /Type /Sig (or untyped) dict with Contents + ByteRange.
+ * - `timestamp`: /V resolves to a /Type /DocTimeStamp dict with Contents + ByteRange.
+ * - `invalid`: /V is present but fails any structural check above.
+ */
+export type SignatureStatus = "unsigned" | "signed" | "timestamp" | "invalid";
+
+/**
  * Signature field.
  */
 export class SignatureField extends TerminalField {
   readonly type = "signature" as const;
 
   /**
-   * Check if field has been signed.
+   * Classify the state of /V on this field.
+   *
+   * Walks the parent chain (signature /V may be inherited) and validates
+   * the signature dictionary shape: /Type must be missing, /Sig, or
+   * /DocTimeStamp, and both /Contents and /ByteRange must be present and
+   * well-formed.
    */
-  isSigned(): boolean {
-    return this.dict.has("V");
+  getSignatureStatus(): SignatureStatus {
+    const value = this.getInheritable("V");
+
+    if (value === null || value.type === "null") {
+      return "unsigned";
+    }
+
+    if (!(value instanceof PdfDict)) {
+      return "invalid";
+    }
+
+    const type = value.getName("Type");
+    const isTimestamp = type?.value === "DocTimeStamp";
+    const isSig = type === undefined || type.value === "Sig";
+
+    if (!isSig && !isTimestamp) {
+      return "invalid";
+    }
+
+    const contents = value.getString("Contents");
+
+    if (!contents || contents.bytes.length === 0) {
+      return "invalid";
+    }
+
+    const byteRange = value.getArray("ByteRange");
+
+    if (!byteRange || byteRange.length !== 4) {
+      return "invalid";
+    }
+
+    for (let i = 0; i < 4; i++) {
+      const item = byteRange.at(i);
+
+      if (!item || item.type !== "number") {
+        return "invalid";
+      }
+    }
+
+    return isTimestamp ? "timestamp" : "signed";
   }
 
   /**
-   * Get signature dictionary (if signed).
+   * True iff the field carries a valid signature or document timestamp.
+   *
+   * Equivalent to `getSignatureStatus() === "signed" || === "timestamp"`.
+   * Returns false for empty placeholder fields, null /V, non-dict /V,
+   * and malformed signature dicts (missing /Contents or /ByteRange).
+   */
+  isSigned(): boolean {
+    const status = this.getSignatureStatus();
+
+    return status === "signed" || status === "timestamp";
+  }
+
+  /**
+   * True iff /V resolves to a /Type /DocTimeStamp dict (PAdES B-LTA).
+   */
+  isDocumentTimestamp(): boolean {
+    return this.getSignatureStatus() === "timestamp";
+  }
+
+  /**
+   * Resolved /V dictionary, walking the parent chain.
+   *
+   * Returns the raw PdfDict regardless of whether it passes shape
+   * validation (use `getSignatureStatus()` for that), so callers can
+   * inspect malformed signatures for forensic / repair purposes.
+   * Returns null when /V is absent or not a dictionary.
    */
   getSignatureDict(): PdfDict | null {
-    return this.dict.getDict("V", this.registry.resolve.bind(this.registry)) ?? null;
+    const value = this.getInheritable("V");
+
+    return value instanceof PdfDict ? value : null;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type {
   ListBoxField,
   RadioField,
   SignatureField,
+  SignatureStatus,
   TextField,
 } from "./document/forms/fields";
 export type { FlattenOptions } from "./document/forms/form-flattener";


### PR DESCRIPTION
## Problem

`SignatureField.isSigned()` was literally `return this.dict.has("V")`. False positives for:

- `/V` present but `PdfNull`.
- `/V` resolves to non-dict (number, string, array).
- `/V` dict missing `/Contents` or `/ByteRange` (corrupt / leftover placeholder).

False negative for:

- `/V` inherited from a parent field (only own dict was checked).

And no way to tell DocTimeStamp signatures (`/Type /DocTimeStamp`) apart from regular signatures.

## Changes

**`SignatureField` (`src/document/forms/fields/other-fields.ts`)**

- New `getSignatureStatus(): "unsigned" | "signed" | "timestamp" | "invalid"` — classifier walks the parent chain via `getInheritable("V")` and validates the sig dict shape (`/Type` missing/`Sig`/`DocTimeStamp`, non-empty `/Contents` `PdfString`, 4-number `/ByteRange`).
- `isSigned()` now ⇔ status ∈ {`signed`, `timestamp`}.
- New `isDocumentTimestamp()`.
- `getSignatureDict()` now honors inheritance and returns the raw `PdfDict` even for malformed-but-present cases, so callers can inspect/repair invalid sigs.

**`PDFForm` (`src/api/pdf-form.ts`)**

- New `getSignedFields(): SignatureField[]` — filter of `getSignatureFields()` via `isSigned()`.

**Exports**

- `SignatureStatus` type re-exported at the package root.

## Behavior delta vs `main`

| Case                           | Old `isSigned()` | New `isSigned()` |
| ------------------------------ | ---------------- | ---------------- |
| No `/V`                        | false            | false            |
| `/V = PdfNull`                 | **true**         | false            |
| `/V` → non-dict primitive      | **true**         | false            |
| `/V` → dict missing `/Contents`/`/ByteRange` | **true** | false      |
| `/V` inherited from parent     | **false**        | true (if valid)  |
| `/V` → `/Type /Sig` + Contents + ByteRange  | true | true             |
| `/V` → `/Type /DocTimeStamp` + Contents + ByteRange | true | true     |

The only internal consumer (`PDFSignature` `findOrCreateSignatureField`, `checkMdpViolation`) always sees `/V` pointing to a Contents+ByteRange-bearing dict in the real sign flow, so no regression there — confirmed by the signing test suite.

## Tests

- New `src/document/forms/fields/other-fields.test.ts` — 13 cases covering every status branch (absent /V, PdfNull, well-formed Sig, untyped (defaults to Sig), DocTimeStamp, inherited via Parent chain, missing/empty Contents, missing/short/non-numeric ByteRange, foreign /Type, non-dict primitive).
- Extended `src/api/pdf-form.test.ts` — `getSignedFields` cases for placeholder exclusion, well-formed sig inclusion, document timestamp inclusion (against `fixtures/forms/sample_form.pdf`).

## Verification

- Full suite: 2953/2965 (12 pre-existing skips), 0 failures.
- Lint: 0 errors (pre-existing warnings untouched).
- Typecheck: clean for this change (pre-existing `Response` errors in unrelated files unchanged).

## Decisions on plan questions

Spec at `.agents/plans/046-signature-field-is-signed.md` left three open questions; resolved as proposed:

1. `"invalid"` does NOT count as signed.
2. `getSignedFields()` includes DocTimeStamp fields.
3. `getSignatureDict()` stays raw; typed `SignatureInfo` deferred to a follow-up.

Closes the gap the spec's "Problem" section calls out; cryptographic signature verification remains a separate Tier-2 goal.